### PR TITLE
✨ feat: Add functionality to create student barcodes for exam missions

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -102,6 +102,7 @@ model exam_mission {
   exam_room_has_exam_mission exam_room_has_exam_mission[]
   student_barcode            student_barcode[]
 
+  @@unique([Subjects_ID, Control_Mission_ID])
   @@index([Control_Mission_ID], map: "fk_Subjects_has_Control_Mission_Control_Mission1_idx")
   @@index([Subjects_ID], map: "fk_Subjects_has_Control_Mission_Subjects1_idx")
   @@index([education_year_ID], map: "fk_exam_mission_education_year1_idx")

--- a/src/Component/Mission/exam_mission/exam_mission.service.ts
+++ b/src/Component/Mission/exam_mission/exam_mission.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/Common/Db/prisma.service';
+import { CreateStudentDto } from 'src/Component/student/dto/create-student.dto';
+import { CreateStudentBarcodeDto } from '../student_barcodes/dto/create-student_barcode.dto';
 import { CreateExamMissionDto } from './dto/create-exam_mission.dto';
 import { UpdateExamMissionDto } from './dto/update-exam_mission.dto';
 
@@ -10,9 +12,64 @@ export class ExamMissionService
 
   async create ( createExamMissionteDto: CreateExamMissionDto )
   {
-    var result = await this.prismaService.exam_mission.create( {
-      data: createExamMissionteDto
+    var unAssignedStudents: Array<CreateStudentDto> = new Array<CreateStudentDto>();
+    var studentsBarcode: Array<CreateStudentBarcodeDto> = new Array<CreateStudentBarcodeDto>();
+    var studentSeatNumbers = await this.prismaService.student_seat_numnbers.findMany( {
+      where: {
+        Control_Mission_ID: createExamMissionteDto.Control_Mission_ID
+      },
+      include: {
+        student: true,
+        control_mission: {
+          select: {
+            schools: {
+              select: {
+                ID: true
+              }
+            }
+          }
+        }
+      }
     } );
+
+    for ( let index = 0; index < studentSeatNumbers.length; index++ )
+    {
+      if ( studentSeatNumbers[ index ].Class_Desk_ID == null || studentSeatNumbers[ index ].Exam_Room_ID == null )
+      {
+        unAssignedStudents.push( studentSeatNumbers[ index ].student );
+        continue;
+      }
+      studentsBarcode.push(
+        {
+          "Student_ID": studentSeatNumbers[ index ].Student_ID,
+          "student_seat_numnbers_ID": studentSeatNumbers[ index ].ID,
+          "Exam_Mission_ID": 0,
+          "Barcode": '' + studentSeatNumbers[ index ].control_mission.schools.ID + createExamMissionteDto.Control_Mission_ID + studentSeatNumbers[ index ].Seat_Number + studentSeatNumbers[ index ].ID
+        },
+      );
+    }
+    if ( unAssignedStudents.length > 0 )
+    {
+      throw { "message": "Some students are not assigned to a seat. Please assign them first. The following students were not assigned: " + unAssignedStudents.map( ( student ) => ( student.First_Name + " " + student.Second_Name + " " + student.Third_Name + " , " ) ) };
+    }
+    var result = await this.prismaService.exam_mission.create( {
+      data: {
+        ...createExamMissionteDto,
+        student_barcode: {
+          createMany: {
+            data: studentsBarcode.map( ( barcode ) =>
+            {
+              return {
+                "Student_ID": barcode.Student_ID,
+                "student_seat_numnbers_ID": barcode.student_seat_numnbers_ID,
+                "Barcode": barcode.Barcode
+              };
+            } )
+          }
+        }
+      }
+    } );
+
     return result;
   }
 


### PR DESCRIPTION
Add logic to create student barcodes based on seat assignment for exam missions. Throw an error if there are unassigned students. Unique constraint added to Subjects_ID and Control_Mission_ID in exam missions.