### PR TITLE
🔍️ feat(exam_mission): add related entities to exam mission

### DIFF
--- a/src/Component/Mission/exam_mission/exam_mission.service.ts
+++ b/src/Component/Mission/exam_mission/exam_mission.service.ts
@@ -88,7 +88,19 @@ export class ExamMissionService
     var results = await this.prismaService.exam_mission.findMany( {
       where: {
         Control_Mission_ID: controlMissionId
-      }
+      },
+      include: {
+        grades: {
+          select: {
+            Name: true
+          },
+        },
+        subjects: {
+          select: {
+            Name: true
+          },
+        },
+      },
     } );
     return results;
   }


### PR DESCRIPTION
Adds the `grades` and `subjects` related entities to the `findMany` query
for the `ExamMissionService`. This allows the front-end to more easily
access the related data for an exam mission.