### PR TITLE
✨ feat(student): Add endpoint to fetch students excluded from a control mission

### DIFF
--- a/src/Component/student/student.controller.ts
+++ b/src/Component/student/student.controller.ts
@@ -67,6 +67,12 @@ export class StudentController
     return this.studentService.findAllBySchoolId( +schoolId );
   }
 
+  @Get( '/controlMission/:controlMissionId' )
+  findAllExcludedByControlMissionId ( @Param( 'controlMissionId' ) controlMissionId: String )
+  {
+    return this.studentService.findAllExcludedByControlMissionId( +controlMissionId );
+  }
+
   @Get( 'school/:schoolId/class/:classId/cohort/:cohortId' )
   findAllBySchoolIdAndClassIdAndCohortId ( @Param( 'schoolId' ) schoolId: string, @Param( 'classId' ) classId: string, @Param( 'cohortId' ) cohortId: string )
   {

--- a/src/Component/student/student.service.ts
+++ b/src/Component/student/student.service.ts
@@ -98,6 +98,42 @@ export class StudentService
     return results;
   }
 
+  async findAllExcludedByControlMissionId ( controlMissionId: number )
+  {
+    var results = await this.prismaService.student.findMany( {
+      where: {
+        student_seat_numnbers: {
+          every: {
+            Control_Mission_ID: {
+              not: controlMissionId
+            }
+          }
+        }
+      },
+      include: {
+        cohort: {
+          select: {
+            ID: true,
+            Name: true
+          }
+        },
+        school_class: {
+          select: {
+            ID: true,
+            Name: true
+          }
+        },
+        grades: {
+          select: {
+            ID: true,
+            Name: true
+          }
+        },
+      },
+    } );
+    return results;
+  }
+
   async findAllBySchoolId ( schoolId: number )
   {
     var results = await this.prismaService.student.findMany( {
@@ -123,7 +159,7 @@ export class StudentService
             Name: true
           }
         },
-      }
+      },
     } );
     return results;
   }


### PR DESCRIPTION
Adds a new endpoint `GET /students/controlMission/:controlMissionId` that returns a list of students excluded from the specified control mission. This is done by querying the `student_seat_numbers` table and checking for any students that do not have the given control mission ID.

The endpoint is implemented in the `StudentController` and the corresponding service method `findAllExcludedByControlMissionId` is added to the `StudentService`. This allows for fetching the relevant student data, including their associated cohort, class, and grades.