### PR TITLE
📦 feat(control-mission): Include student seat numbers count in response

### DIFF
--- a/src/Component/Mission/control_mission/control_mission.service.ts
+++ b/src/Component/Mission/control_mission/control_mission.service.ts
@@ -97,6 +97,14 @@ export class ControlMissionService
         Education_year_ID: educationYearId,
         Schools_ID: schoolId
       },
+      include: {
+        _count: {
+          select: {
+            student_seat_numnbers: true,
+          },
+        },
+      },
+
     } );
     return results;
   }
@@ -116,7 +124,7 @@ export class ControlMissionService
     var results = await this.prismaService.control_mission.findMany( {
       where: {
         Education_year_ID: educationYearId
-      }
+      },
     } );
     return results;
   }


### PR DESCRIPTION
Adds the count of student seat numbers to the response of the `getControlMissionsByEducationYearAndSchool` method. This change provides more detailed information about the control missions, enabling better analysis and decision-making.