### PR TITLE
✨ feat(student_barcodes.service): add subject details to exam mission

### DIFF
--- a/src/Component/Mission/student_barcodes/student_barcodes.service.ts
+++ b/src/Component/Mission/student_barcodes/student_barcodes.service.ts
@@ -75,6 +75,16 @@ export class StudentBarcodesService
       },
 
       include: {
+        exam_mission: {
+          include: {
+            subjects: {
+              select: {
+                ID: true,
+                Name: true,
+              },
+            },
+          },
+        },
         student: {
           select: {
             ID: true,


### PR DESCRIPTION
Adds the subject ID and Name to the `exam_mission` include in the
`StudentBarcodesService`. This allows the frontend to retrieve the
subject details along with the exam mission data, providing a more
complete set of information for the student barcodes feature.