### PR TITLE
🔒️ feat: Add JWT authentication and role-based access control to Exam Mission API

### DIFF
--- a/src/Component/Mission/exam_mission/exam_mission.controller.ts
+++ b/src/Component/Mission/exam_mission/exam_mission.controller.ts
@@ -1,13 +1,14 @@
 import { File, FileInterceptor } from '@nest-lab/fastify-multer';
-import { Body, Controller, Delete, Get, Param, ParseFilePipeBuilder, Patch, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, ParseFilePipeBuilder, Patch, Post, UploadedFile, UseGuards, UseInterceptors } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/Common/Guard/local-auth.guard';
 import Role from 'src/Common/Guard/role.enum';
 import { Roles } from 'src/Common/Guard/roles.decorator';
 import { CreateExamMissionDto } from './dto/create-exam_mission.dto';
 import { UpdateExamMissionDto } from './dto/update-exam_mission.dto';
 import { ExamMissionService } from './exam_mission.service';
 
-// @UseGuards( JwtAuthGuard )
+@UseGuards( JwtAuthGuard )
 @ApiTags( "Exam-Mission" )
 @Controller( 'exam-mission' )
 export class ExamMissionController
@@ -51,7 +52,7 @@ export class ExamMissionController
     return this.examMissionService.findOne( +id );
   }
 
-  // @Roles( Role.SuperAdmin )
+  @Roles( Role.SuperAdmin )
   @UseInterceptors( FileInterceptor( 'pdf' ) )
   @Patch( ':id' )
   update ( @Param( 'id' ) id: string, @Body() updateExamMissionDto: UpdateExamMissionDto, @UploadedFile(


### PR DESCRIPTION
This commit introduces the following changes:

1. Adds the `JwtAuthGuard` to the `ExamMissionController` to enforce JWT authentication.
2. Adds the `@Roles()` decorator to the `update` method, restricting access to only the `SuperAdmin` role.
3. Removes the commented-out `JwtAuthGuard` and `@Roles()` decorators, as they are now being used.

These changes ensure that the Exam Mission API is properly secured and accessible only to authenticated users with the appropriate permissions.