### PR TITLE
📝 feat(prisma): Cascade delete exam missions from exam rooms

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -388,7 +388,7 @@ model control_mission_has_grades {
 model exam_room_has_exam_mission {
   exam_room_ID    Int
   exam_mission_ID Int
-  exam_mission    exam_mission @relation(fields: [exam_mission_ID], references: [ID], onDelete: NoAction, onUpdate: NoAction, map: "fk_exam_room_has_exam_mission_exam_mission1")
+  exam_mission    exam_mission @relation(fields: [exam_mission_ID], references: [ID], onDelete: Cascade, onUpdate: NoAction, map: "fk_exam_room_has_exam_mission_exam_mission1")
   exam_room       exam_room    @relation(fields: [exam_room_ID], references: [ID], onDelete: NoAction, onUpdate: NoAction, map: "fk_exam_room_has_exam_mission_exam_room1")
 
   @@id([exam_room_ID, exam_mission_ID])


### PR DESCRIPTION
The changes in this commit update the `exam_room_has_exam_mission` model to
cascade delete exam missions when an exam room is deleted. This ensures that
the deletion of an exam room also removes the associated exam missions,
maintaining data integrity.