### PR TITLE
✨ feat(prisma): enable period and create_only by default

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -84,8 +84,8 @@ model exam_mission {
   Month                      String                       @db.VarChar(45)
   Year                       String                       @db.VarChar(45)
   FinalDegree                String                       @default("100") @db.VarChar(45)
-  Period                     Boolean                      @default(false)
-  Create_Only                Boolean                      @default(false)
+  Period                     Boolean                      @default(true)
+  Create_Only                Boolean                      @default(true)
   duration                   Int?
   start_time                 DateTime?                    @db.DateTime(0)
   end_time                   DateTime?                    @db.DateTime(0)
@@ -416,7 +416,7 @@ model proctor_in_room {
   exam_room_ID Int
   Month        String    @db.VarChar(45)
   Year         String    @db.VarChar(45)
-  Period       Boolean   @default(false)
+  Period       Boolean   @default(true)
   Attendance   String?   @db.VarChar(45)
   Active       String    @default("1") @db.VarChar(45)
   Created_By   Int


### PR DESCRIPTION
Changes the default values of the `period` and `create_only` fields in the
`proctor_in_room` and `exam_mission` models to `true`. This ensures that
new records created for these models will have the period and create_only
flags enabled by default, simplifying the workflow for users.