### PR TITLE
🐛 fix(proctor): remove console.log calls

### DIFF
--- a/src/Component/proctor/proctor.controller.ts
+++ b/src/Component/proctor/proctor.controller.ts
@@ -45,9 +45,6 @@ export class ProctorController
   @Get( '/exam-room/:exam_room_id' )
   async findAllByExamRoomId ( @Param( 'exam_room_id' ) exam_room_id: string, @Query( 'month' ) month: string, @Query( 'year' ) year: string )
   {
-
-    console.log( 'exam_room_id : ' + exam_room_id + ' month : ' + month + ' year : ' + year );
-
     return this.proctorService.findAllByExamRoomId( +exam_room_id, month, year );
   }
 


### PR DESCRIPTION
The console.log calls in the `findAllByExamRoomId` method of the `ProctorController` have been removed. This was done to clean up the code and remove unnecessary debugging statements.