### PR TITLE
✨🐛 fix(ExamMission): update start_time and end_time validation

### DIFF
--- a/src/Component/Mission/exam_mission/dto/create-exam_mission.dto.ts
+++ b/src/Component/Mission/exam_mission/dto/create-exam_mission.dto.ts
@@ -1,7 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsNumber, IsString } from 'class-validator';
+import { IsBoolean, IsISO8601, IsNumber, IsString } from 'class-validator';
 
-export class CreateExamMissionDto {
+export class CreateExamMissionDto
+{
   @ApiProperty()
   @IsNumber()
   Subjects_ID: number;
@@ -43,11 +44,11 @@ export class CreateExamMissionDto {
   duration?: number | null;
 
   @ApiProperty()
-  @IsString()
+  @IsISO8601()
   start_time?: Date | string | null;
 
   @ApiProperty()
-  @IsString()
+  @IsISO8601()
   end_time?: Date | string | null;
 
   @ApiProperty()


### PR DESCRIPTION
This commit updates the validation for the `start_time` and `end_time` fields in the `CreateExamMissionDto` class. The previous validation used `@IsString()`, which allowed for string input, but the fields are intended to store `Date` objects. The new validation uses `@IsISO8601()` to ensure that the input is a valid ISO 8601 date string, which can be easily converted to a `Date` object.