### PR TITLE
✨🔧 feat(student_barcode): set default value for AttendanceStatusId

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -266,7 +266,7 @@ model student_barcode {
   Student_ID               Int
   student_seat_numnbers_ID Int
   Barcode                  String                @unique(map: "Barcode_UNIQUE") @db.VarChar(45)
-  AttendanceStatusId       Int?
+  AttendanceStatusId       Int                   @default(0)
   StudentDegree            String?               @db.VarChar(45)
   Exam_Version             String                @default("A") @db.VarChar(1)
   isCheating               Int                   @default(0) @db.TinyInt


### PR DESCRIPTION
Sets the default value for the `AttendanceStatusId` field in the `student_barcode` model to `0`. This change ensures that a valid value is always present for this field, even if no explicit value is provided during record creation.