### PR TITLE
🔐 feat(proctor): Add role-based access control for control mission endpoint

### DIFF
--- a/src/Component/proctor/proctor.controller.ts
+++ b/src/Component/proctor/proctor.controller.ts
@@ -109,6 +109,8 @@ export class ProctorController
     return this.proctorService.remove( +id );
   }
 
+  @Roles( Role.Proctor )
+  @Get( '/control-mission' )
   async findAllControlMissions ( @Req() req: Request )
   {
     return this.proctorService.findAllControlMissionsByProctorId(


### PR DESCRIPTION
Adds a `@Roles` decorator to restrict access to the `findAllControlMissions` endpoint
to only users with the `Proctor` role. This ensures that only authorized proctors can
access the control mission data.