### PR TITLE
🔥 feat(StudentBarcodes): change route to GET for marking student attendance

### DIFF
--- a/src/Component/Mission/student_barcodes/student_barcodes.controller.ts
+++ b/src/Component/Mission/student_barcodes/student_barcodes.controller.ts
@@ -126,7 +126,7 @@ export class StudentBarcodesController
   }
 
   @Roles( Role.Student )
-  @Post( 'mark-attended/:barcode' )
+  @Get( 'mark-attended/:barcode' )
   async markStudentAttended ( @Param( 'barcode' ) barcode: string )
   {
     var result = await this.studentBarcodesService.markStudentAttended( barcode );


### PR DESCRIPTION
Modify the `mark-attended/:barcode` route to use the `@Get` decorator instead of `@Post`. This change allows students to mark their attendance by making a GET request to the endpoint, which is more intuitive and aligns with the purpose of the action.