### PR TITLE
🌟 feat(subjects): Enhance subject filtering and fetching

### DIFF
--- a/src/Component/School_Setting/subjects/subjects.service.ts
+++ b/src/Component/School_Setting/subjects/subjects.service.ts
@@ -42,11 +42,27 @@ export class SubjectsService
     var results = await this.prismaService.subjects.findMany( {
       where: {
         school_type_has_subjects: {
-          every: {
+          some: {
             school_type_ID
+          },
+        },
+      },
+      select: {
+        ID: true,
+        Name: true,
+        InExam: true,
+        Active: true,
+        school_type_has_subjects: {
+          select: {
+            school_type: {
+              select: {
+                ID: true,
+                Name: true
+              }
+            }
           }
         }
-      }
+      },
     } );
     return results.map( ( obj ) => obj );
   }
@@ -94,17 +110,6 @@ export class SubjectsService
           subjects_ID: result.ID,
         },
       } );
-    } );
-    return result;
-  }
-
-  async connectSubjectToSchoolType ( id: number, school_type_ID: number )
-  {
-    var result = await this.prismaService.school_type_has_subjects.create( {
-      data: {
-        school_type_ID,
-        subjects_ID: id,
-      },
     } );
     return result;
   }


### PR DESCRIPTION
This commit introduces the following improvements to the subjects service:

1. Modify the `getSubjectsBySchoolType` method to fetch subjects based on the `some` condition instead of `every`. This allows retrieving subjects that are associated with at least one of the specified school types.

2. Enhance the `getSubjectsBySchoolType` method to include additional information, such as the associated school types, in the response data. This provides more context for the retrieved subjects.

3. Remove the `connectSubjectToSchoolType` method, as it is no longer needed due to the changes in the `getSubjectsBySchoolType` method.

These changes improve the flexibility and functionality of the subjects service, allowing for more efficient and informative retrieval of subjects based on school types.