### PR TITLE
✨ feat: Add Swagger documentation only in non-production environments

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -76,10 +76,15 @@ async function bootstrap ()
     .addTag( 'Uuid' )
     .build();
 
-  const document = SwaggerModule.createDocument( app, config );
-  SwaggerModule.setup( 'swagger', app, document, {
-    swaggerOptions: {},
-  } );
+  if ( process.env.NODE_ENV !== 'production' )
+  {
+    const document = SwaggerModule.createDocument( app, config );
+    SwaggerModule.setup( 'swagger', app, document, {
+      swaggerOptions: {},
+    } );
+  }
+
+
   await app.listen( 3333, '0.0.0.0' );
   if ( module.hot )
   {


### PR DESCRIPTION
The changes made in this commit enable Swagger documentation in the application,
but only when the application is running in a non-production environment. This
helps to keep the production environment clean and secure, while still
providing a way to view the API documentation during development.