### PR TITLE
🔍 feat(proctor): add control mission filter to exam room queries

### DIFF
--- a/src/Component/proctor/proctor.service.ts
+++ b/src/Component/proctor/proctor.service.ts
@@ -205,6 +205,9 @@ export class ProctorService
       var data = await this.prismaService.exam_room_has_exam_mission.findMany( {
         where: {
           exam_room: {
+            control_mission: {
+              ID: controlMissionId,
+            },
             Stage: proctorData.isFloorManager,
             school_class: {
               Schools_ID: proctorData.School_Id,
@@ -293,6 +296,9 @@ export class ProctorService
           await this.prismaService.exam_room_has_exam_mission.findMany( {
             where: {
               exam_room: {
+                control_mission: {
+                  ID: controlMissionId,
+                },
                 ID: mission.exam_room_ID,
               },
               AND: {


### PR DESCRIPTION
Adds a new filter to the `exam_room_has_exam_mission` queries to only return
exam rooms that are associated with the provided `controlMissionId`. This
ensures that proctors only see exam rooms that are part of the control mission
they are responsible for.