### PR TITLE
🔧 refactor(ExamRoomsService): fix date format in query param

### DIFF
--- a/src/Component/Mission/exam_rooms/exam_rooms.service.ts
+++ b/src/Component/Mission/exam_rooms/exam_rooms.service.ts
@@ -36,7 +36,7 @@ export class ExamRoomsService
           gte:
             '' +
             currentDate.getUTCDate() +
-            ',' +
+            ' ' +
             ( currentDate.getUTCMonth() + 1 ),
         },
         Year: '' + currentDate.getUTCFullYear(),


### PR DESCRIPTION
The date format in the `gte` query parameter was incorrect, using a
comma instead of a space to separate the day and month. This change
fixes the date format to use a space, ensuring the query parameters
are properly formatted.