### PR TITLE
feat(🎨): Refactor subject access control logic

### DIFF
--- a/src/Component/School_Setting/subjects/subjects.controller.ts
+++ b/src/Component/School_Setting/subjects/subjects.controller.ts
@@ -34,7 +34,6 @@ export class SubjectsController
     );
   }
 
-  @Roles( Role.SuperAdmin )
   @Get()
   findAll ()
   {


### PR DESCRIPTION
Removes the `@Roles(Role.SuperAdmin)` decorator from the `findAll` method
in the `SubjectsController` class. This change simplifies the access
control logic by relying on the default behavior of the `@Get()` decorator
to authorize access to the endpoint.