### PR TITLE
✨ feat: update refresh token expiration time

### DIFF
--- a/src/Component/auth/entities/refreshtoken.entities.ts
+++ b/src/Component/auth/entities/refreshtoken.entities.ts
@@ -18,7 +18,7 @@ class RefreshToken
 
   sign (): string
   {
-    return sign( { ...this, signOptions: { expiresIn: '30d' } }, '22555BB344931F6EB4D6C6C3973F1' );
+    return sign( { ...this, signOptions: { expiresIn: '18h' } }, '22555BB344931F6EB4D6C6C3973F1' );
   }
 }
 


### PR DESCRIPTION
This commit updates the refresh token expiration time from 30 days to 18 hours.
This change is made to improve the security of the application by reducing the
window of opportunity for unauthorized access.