### PR TITLE
🚀 feat(control_mission): Implement dynamic seat number assignment

### DIFF
--- a/src/Component/Mission/control_mission/control_mission.service.ts
+++ b/src/Component/Mission/control_mission/control_mission.service.ts
@@ -77,15 +77,24 @@ export class ControlMissionService
 
     for ( var i = 0; i < studentsinMission.length; i++ )
     {
+      var lastSeatInGrade = await this.prismaService.student_seat_numnbers.findFirst( {
+        where: {
+          Grades_ID: studentsinMission[ i ].grades.ID,
+          Control_Mission_ID: createStudentSeatNumberDto.controlMissionId,
+        },
+        orderBy: {
+          Seat_Number: 'desc',
+        },
+      } );
+
       if ( i == 0 )
       {
-        seatNumbers[ i ] =
-          parseInt( studentsinMission[ i ].grades.Name.split( ' ' )[ 1 ] ) * 1000 + 1;
+        seatNumbers[ i ] = lastSeatInGrade ? parseInt( lastSeatInGrade.Seat_Number ) + 1 : parseInt( studentsinMission[ i ].grades.Name.split( ' ' )[ 1 ] ) * 1000 + 1;
       } else if (
         studentsinMission[ i ].grades.Name != studentsinMission[ i - 1 ].grades.Name
       )
       {
-        seatNumbers[ i ] =
+        seatNumbers[ i ] = lastSeatInGrade ? parseInt( lastSeatInGrade.Seat_Number ) + 1 :
           parseInt( studentsinMission[ i ].grades.Name.split( ' ' )[ 1 ] ) * 1000 + 1;
       } else
       {


### PR DESCRIPTION
This change introduces a more dynamic approach to assigning seat numbers for
students in a control mission. Previously, the seat number was calculated
based on the grade name, which could lead to issues if the grade name
structure changed. The new implementation retrieves the last assigned seat
number for a given grade and control mission, and assigns the next available
seat number. This ensures that the seat numbers are unique and consecutive
within each grade, even if the grade names change.