### PR TITLE
🔍 feat(exam-rooms): include exam mission and related entities

### DIFF
--- a/src/Component/Mission/exam_rooms/exam_rooms.service.ts
+++ b/src/Component/Mission/exam_rooms/exam_rooms.service.ts
@@ -28,14 +28,14 @@ export class ExamRoomsService
       include: {
         school_class: true,
         control_mission: {
-          // include: {
-          // exam_mission: {
-          //   include: {
-          //     grades: true,
-          //     subjects: true,
-          //   }
-          // }
-          // }
+          include: {
+            exam_mission: {
+              include: {
+                grades: true,
+                subjects: true,
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Includes the `exam_mission` entity and its related `grades` and `subjects`
entities in the `exam_rooms` service's `include` options. This allows the
service to fetch and return the complete exam mission data alongside the
control mission data.