### PR TITLE
feat: Add null check for user and role data

### DIFF
--- a/src/Users_System/users/users.service.ts
+++ b/src/Users_System/users/users.service.ts
@@ -312,13 +312,15 @@ export class UsersService {
         },
       },
     });
-    var roles = [];
-    result.users_has_roles.forEach((role) => {
-      roles.push(role.roles);
-    });
+    if (result) {
+      var roles = [];
+      result.users_has_roles.forEach((role) => {
+        roles.push(role.roles);
+      });
 
-    (result as any).Roles = roles;
-    result.users_has_roles = undefined;
+      (result as any).Roles = roles;
+      result.users_has_roles = undefined;
+    }
 
     return result;
   }
@@ -482,14 +484,14 @@ export class UsersService {
         },
       },
     });
-    var roles = [];
-    result.users_has_roles.forEach((role) => {
-      roles.push(role.roles);
-    });
-
-    (result as any).Roles = roles;
-    result.users_has_roles = undefined;
-
+    if (result) {
+      var roles = [];
+      result.users_has_roles.forEach((role) => {
+        roles.push(role.roles);
+      });
+      (result as any).Roles = roles;
+      result.users_has_roles = undefined;
+    }
     return result;
   }
 
@@ -580,13 +582,15 @@ export class UsersService {
       },
     });
 
-    var roles = [];
-    result.users_has_roles.forEach((role) => {
-      roles.push(role.roles);
-    });
+    if (result) {
+      var roles = [];
+      result.users_has_roles.forEach((role) => {
+        roles.push(role.roles);
+      });
 
-    (result as any).Roles = roles;
-    result.users_has_roles = undefined;
+      (result as any).Roles = roles;
+      result.users_has_roles = undefined;
+    }
 
     return result;
   }


### PR DESCRIPTION
The changes made in this commit ensure that the user and role data is properly handled when the `findOneUser()`, `findUserByUsername()`, and `findUserById()` methods return null or undefined values. This is done by adding a conditional check to handle the case where the `result` object is falsy. This ensures that the code does not attempt to access properties of a null or undefined object, which could lead to runtime errors.