### PR TITLE
🎨 feat(prisma): Migrate Prisma service to module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,15 +127,16 @@
       }
     },
     "node_modules/@angular-devkit/schematics-cli": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-17.1.2.tgz",
-      "integrity": "sha512-bvXykYzSST05qFdlgIzUguNOb3z0hCa8HaTwtqdmQo9aFPf+P+/AC56I64t1iTchMjQtf3JrBQhYM25gUdcGbg==",
+      "version": "17.3.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-17.3.8.tgz",
+      "integrity": "sha512-TjmiwWJarX7oqvNiRAroQ5/LeKUatxBOCNEuKXO/PV8e7pn/Hr/BqfFm+UcYrQoFdZplmtNAfqmbqgVziKvCpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "17.1.2",
-        "@angular-devkit/schematics": "17.1.2",
+        "@angular-devkit/core": "17.3.8",
+        "@angular-devkit/schematics": "17.3.8",
         "ansi-colors": "4.1.3",
-        "inquirer": "9.2.12",
+        "inquirer": "9.2.15",
         "symbol-observable": "4.0.0",
         "yargs-parser": "21.1.1"
       },
@@ -148,11 +149,59 @@
         "yarn": ">= 1.13.0"
       }
     },
+    "node_modules/@angular-devkit/schematics-cli/node_modules/@angular-devkit/core": {
+      "version": "17.3.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.8.tgz",
+      "integrity": "sha512-Q8q0voCGudbdCgJ7lXdnyaxKHbNQBARH68zPQV72WT8NWy+Gw/tys870i6L58NWbBaCJEUcIj/kb6KoakSRu+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "8.12.0",
+        "ajv-formats": "2.1.1",
+        "jsonc-parser": "3.2.1",
+        "picomatch": "4.0.1",
+        "rxjs": "7.8.1",
+        "source-map": "0.7.4"
+      },
+      "engines": {
+        "node": "^18.13.0 || >=20.9.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.5.2"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular-devkit/schematics-cli/node_modules/@angular-devkit/schematics": {
+      "version": "17.3.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.8.tgz",
+      "integrity": "sha512-QRVEYpIfgkprNHc916JlPuNbLzOgrm9DZalHasnLUz4P6g7pR21olb8YCyM2OTJjombNhya9ZpckcADU5Qyvlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/core": "17.3.8",
+        "jsonc-parser": "3.2.1",
+        "magic-string": "0.30.8",
+        "ora": "5.4.1",
+        "rxjs": "7.8.1"
+      },
+      "engines": {
+        "node": "^18.13.0 || >=20.9.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
     "node_modules/@angular-devkit/schematics-cli/node_modules/chalk": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
       "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -165,51 +214,25 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
       "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">= 12"
       }
     },
-    "node_modules/@angular-devkit/schematics-cli/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@angular-devkit/schematics-cli/node_modules/figures": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "^5.0.0",
-        "is-unicode-supported": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@angular-devkit/schematics-cli/node_modules/inquirer": {
-      "version": "9.2.12",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.12.tgz",
-      "integrity": "sha512-mg3Fh9g2zfuVWJn6lhST0O7x4n03k7G8Tx5nvikJkbq8/CK47WDVm+UznF0G6s5Zi0KcyUisr6DU8T67N5U+1Q==",
+      "version": "9.2.15",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.15.tgz",
+      "integrity": "sha512-vI2w4zl/mDluHt9YEQ/543VTCwPKWiHzKtm9dM2V0NdFcqEexDAjUHzO1oA60HRNaVifGXXM1tRRNluLVHa0Kg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@ljharb/through": "^2.3.11",
+        "@ljharb/through": "^2.3.12",
         "ansi-escapes": "^4.3.2",
         "chalk": "^5.3.0",
         "cli-cursor": "^3.1.0",
         "cli-width": "^4.1.0",
         "external-editor": "^3.1.0",
-        "figures": "^5.0.0",
+        "figures": "^3.2.0",
         "lodash": "^4.17.21",
         "mute-stream": "1.0.0",
         "ora": "^5.4.1",
@@ -220,19 +243,27 @@
         "wrap-ansi": "^6.2.0"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
       }
     },
-    "node_modules/@angular-devkit/schematics-cli/node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+    "node_modules/@angular-devkit/schematics-cli/node_modules/jsonc-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@angular-devkit/schematics-cli/node_modules/magic-string": {
+      "version": "0.30.8",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@angular-devkit/schematics-cli/node_modules/mute-stream": {
@@ -240,8 +271,22 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
       "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@angular-devkit/schematics-cli/node_modules/picomatch": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.1.tgz",
+      "integrity": "sha512-xUXwsxNjwTQ8K3GnT4pCJm+xq3RUPQbmkYJTP5aFIfNIvbcc/4MUxgBaaRSZJ6yGJZiGSyYlM6MzwTsRk8SYCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@angular-devkit/schematics-cli/node_modules/run-async": {
@@ -249,6 +294,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
       "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -842,6 +888,7 @@
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
@@ -1330,6 +1377,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -1346,6 +1394,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1357,6 +1406,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1367,12 +1417,14 @@
     "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -1389,6 +1441,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -1403,6 +1456,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -1894,6 +1948,7 @@
       "resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.13.tgz",
       "integrity": "sha512-/gKJun8NNiWGZJkGzI/Ragc53cOdcLNdzjLaIa+GEjguQs0ulsurx8WN0jijdK9yPqDvziX995sMRLyLt1uZMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7"
       },
@@ -1947,32 +2002,30 @@
       }
     },
     "node_modules/@nestjs/cli": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.3.2.tgz",
-      "integrity": "sha512-aWmD1GLluWrbuC4a1Iz/XBk5p74Uj6nIVZj6Ov03JbTfgtWqGFLtXuMetvzMiHxfrHehx/myt2iKAPRhKdZvTg==",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.4.5.tgz",
+      "integrity": "sha512-FP7Rh13u8aJbHe+zZ7hM0CC4785g9Pw4lz4r2TTgRtf0zTxSWMkJaPEwyjX8SK9oWK2GsYxl+fKpwVZNbmnj9A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "17.1.2",
-        "@angular-devkit/schematics": "17.1.2",
-        "@angular-devkit/schematics-cli": "17.1.2",
+        "@angular-devkit/core": "17.3.8",
+        "@angular-devkit/schematics": "17.3.8",
+        "@angular-devkit/schematics-cli": "17.3.8",
         "@nestjs/schematics": "^10.0.1",
         "chalk": "4.1.2",
         "chokidar": "3.6.0",
-        "cli-table3": "0.6.3",
+        "cli-table3": "0.6.5",
         "commander": "4.1.1",
         "fork-ts-checker-webpack-plugin": "9.0.2",
-        "glob": "10.3.10",
+        "glob": "10.4.2",
         "inquirer": "8.2.6",
         "node-emoji": "1.11.0",
         "ora": "5.4.1",
-        "rimraf": "4.4.1",
-        "shelljs": "0.8.5",
-        "source-map-support": "0.5.21",
         "tree-kill": "1.2.2",
         "tsconfig-paths": "4.2.0",
         "tsconfig-paths-webpack-plugin": "4.1.0",
         "typescript": "5.3.3",
-        "webpack": "5.90.1",
+        "webpack": "5.94.0",
         "webpack-node-externals": "3.0.0"
       },
       "bin": {
@@ -1982,7 +2035,7 @@
         "node": ">= 16.14"
       },
       "peerDependencies": {
-        "@swc/cli": "^0.1.62 || ^0.3.0",
+        "@swc/cli": "^0.1.62 || ^0.3.0 || ^0.4.0",
         "@swc/core": "^1.3.62"
       },
       "peerDependenciesMeta": {
@@ -1992,6 +2045,86 @@
         "@swc/core": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/cli/node_modules/@angular-devkit/core": {
+      "version": "17.3.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.8.tgz",
+      "integrity": "sha512-Q8q0voCGudbdCgJ7lXdnyaxKHbNQBARH68zPQV72WT8NWy+Gw/tys870i6L58NWbBaCJEUcIj/kb6KoakSRu+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "8.12.0",
+        "ajv-formats": "2.1.1",
+        "jsonc-parser": "3.2.1",
+        "picomatch": "4.0.1",
+        "rxjs": "7.8.1",
+        "source-map": "0.7.4"
+      },
+      "engines": {
+        "node": "^18.13.0 || >=20.9.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.5.2"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/cli/node_modules/@angular-devkit/schematics": {
+      "version": "17.3.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.8.tgz",
+      "integrity": "sha512-QRVEYpIfgkprNHc916JlPuNbLzOgrm9DZalHasnLUz4P6g7pR21olb8YCyM2OTJjombNhya9ZpckcADU5Qyvlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/core": "17.3.8",
+        "jsonc-parser": "3.2.1",
+        "magic-string": "0.30.8",
+        "ora": "5.4.1",
+        "rxjs": "7.8.1"
+      },
+      "engines": {
+        "node": "^18.13.0 || >=20.9.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@nestjs/cli/node_modules/jsonc-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nestjs/cli/node_modules/magic-string": {
+      "version": "0.30.8",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@nestjs/cli/node_modules/picomatch": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.1.tgz",
+      "integrity": "sha512-xUXwsxNjwTQ8K3GnT4pCJm+xq3RUPQbmkYJTP5aFIfNIvbcc/4MUxgBaaRSZJ6yGJZiGSyYlM6MzwTsRk8SYCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@nestjs/cli/node_modules/typescript": {
@@ -2005,53 +2138,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/@nestjs/cli/node_modules/webpack": {
-      "version": "5.90.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.90.1.tgz",
-      "integrity": "sha512-SstPdlAC5IvgFnhiRok8hqJo/+ArAbNv7rhU4fnWGHNVfN59HSQFaxZDSAL3IFG2YmqxuRs+IU33milSxbPlog==",
-      "dev": true,
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.5",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.21.10",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.10",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "node_modules/@nestjs/common": {
@@ -2491,6 +2577,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -2784,31 +2871,12 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/eslint": {
-      "version": "8.56.10",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
-      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "4.17.21",
@@ -3456,11 +3524,12 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -3531,6 +3600,7 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -4287,10 +4357,11 @@
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
-      "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "string-width": "^4.2.0"
       },
@@ -4880,7 +4951,8 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -4974,10 +5046,11 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.0.tgz",
-      "integrity": "sha512-O+QWCviPNSSLAD9Ucn8Awv+poAkqn3T1XY5/N7kR7rQO9yfSGWkYZDwpJ+iKF7B8rxaQKWngSqACpgzeapSyoA==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -6259,21 +6332,23 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "node_modules/glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
+      "integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6763,15 +6838,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -7194,14 +7260,12 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
-      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -8339,12 +8403,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -8434,9 +8499,10 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
-      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -8823,6 +8889,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -8944,27 +9016,26 @@
       "dev": true
     },
     "node_modules/path-scurry": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
-      "integrity": "sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
-      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
-      "engines": {
-        "node": "14 || >=16.14"
-      }
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "3.2.0",
@@ -9564,18 +9635,6 @@
         "node": ">= 12.13.0"
       }
     },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/reflect-metadata": {
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
@@ -9748,75 +9807,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
-    },
-    "node_modules/rimraf": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
-      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^9.2.0"
-      },
-      "bin": {
-        "rimraf": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "minimatch": "^8.0.2",
-        "minipass": "^4.2.4",
-        "path-scurry": "^1.6.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minipass": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/run-async": {
       "version": "2.4.1",
@@ -10103,43 +10093,6 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/shelljs/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/side-channel": {
@@ -10433,6 +10386,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -10458,6 +10412,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -10587,6 +10542,7 @@
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
       "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
@@ -11331,22 +11287,21 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/webpack": {
-      "version": "5.91.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
-      "integrity": "sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==",
+      "version": "5.94.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
+      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
         "@webassemblyjs/wasm-edit": "^1.12.1",
         "@webassemblyjs/wasm-parser": "^1.12.1",
         "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
+        "acorn-import-attributes": "^1.9.5",
         "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.16.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -11518,6 +11473,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -318,13 +318,13 @@ model subjects {
 }
 
 model system_logger {
-  ID           Int      @id @unique(map: "ID_UNIQUE") @default(autoincrement())
-  TableName    String   @db.VarChar(45)
-  Action       String   @db.VarChar(45)
-  UserId       String   @db.VarChar(45)
-  Date         DateTime @default(now()) @db.Timestamp(0)
-  Record_Befor String?  @db.VarChar(45)
-  Record_After String?  @db.VarChar(45)
+  ID           Int     @id @unique(map: "ID_UNIQUE") @default(autoincrement())
+  TableName    String  @db.VarChar(45)
+  Action       String  @db.VarChar(45)
+  UserId       String  @db.VarChar(45)
+  Date         String  @db.VarChar(45)
+  Record_Befor String? @db.VarChar(45)
+  Record_After String? @db.VarChar(45)
 }
 
 model users {

--- a/src/Common/Db/prisma.module.ts
+++ b/src/Common/Db/prisma.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/src/Common/Db/prisma.service.ts
+++ b/src/Common/Db/prisma.service.ts
@@ -1,11 +1,84 @@
 import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit {
-  async onModuleInit() {
-    await this.$connect();
+  constructor() {
+    super({ log: ['query', 'info', 'warn', 'error'] });
+    this.$extends({
+      name: 'logger',
+      query: {
+        $allModels: {
+          $allOperations: async ({ operation, args, query, model }) => {
+            var result = await query(args);
+            console.log(
+              'operation',
+              operation,
+              'args',
+              args,
+              'query',
+              query,
+              'model',
+              model,
+              'result',
+              result,
+            );
+            return result;
+          },
+        },
+      },
+    });
   }
+
+  async onModuleInit() {
+    // Register Prisma event handlers
+
+    // this.$extends({
+    //   name: 'test',
+    //   query: {
+    //     $allModels: {
+    //       $allOperations: async ({ operation, args, query, model }) => {
+    //         var result = await query(args);
+    //         console.log(
+    //           'operation',
+    //           operation,
+    //           'args',
+    //           args,
+    //           'query',
+    //           query,
+    //           'model',
+    //           model,
+    //           'result',
+    //           result,
+    //         );
+
+    //         return result;
+    //       },
+    //     },
+    //   },
+    // });
+
+    await this.$connect();
+
+    // this.$use(async (params, next) => {
+    //   const result = await next(params);
+    //   console.log('Query Result: ', result);
+    //   return result;
+    // });
+  }
+
+  private logMiddleware: Prisma.Middleware = async (params, next) => {
+    // Log query details before execution
+    console.log('Query:', params);
+
+    // Execute the query
+    const result = await next(params);
+
+    // Log query result after execution
+    console.log('Result:', result);
+
+    return result;
+  };
 
   async enableShutdownHooks(app: INestApplication) {
     this.$disconnect();

--- a/src/Common/MiddleWare/prisma_middle_were.ts
+++ b/src/Common/MiddleWare/prisma_middle_were.ts
@@ -1,0 +1,41 @@
+// import { PrismaClient } from '@prisma/client';
+
+// // Initialize Prisma Client
+// const prisma = new PrismaClient().$extends({
+//   query: {
+//     $queryRaw: async ({ args, query, operation }) => {
+//       // handle $queryRaw operation
+//       console.log('args', args, 'query', query, 'operation', operation);
+//       var result = await query(args);
+//       console.log('result', result);
+//       return result;
+//     },
+//     $executeRaw: async ({ args, query, operation }) => {
+//       // handle $executeRaw operation
+//       console.log('args', args, 'query', query, 'operation', operation);
+//       var result = await query(args);
+//       console.log('result', result);
+
+//       return result;
+//     },
+//     $queryRawUnsafe: async ({ args, query, operation }) => {
+//       // handle $queryRawUnsafe operation
+//       console.log('args', args, 'query', query, 'operation', operation);
+//       var result = await query(args);
+//       console.log('result', result);
+
+//       return result;
+//     },
+//     $executeRawUnsafe: async ({ args, query, operation }) => {
+//       // handle $executeRawUnsafe operation
+//       console.log('args', args, 'query', query, 'operation', operation);
+//       var result = await query(args);
+//       console.log('result', result);
+//       return result;
+//     },
+//   },
+
+//   // Add your custom middleware here
+// });
+
+// export { prisma };

--- a/src/Common/logging.interceptor.ts
+++ b/src/Common/logging.interceptor.ts
@@ -7,29 +7,26 @@ import {
 } from '@nestjs/common';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { Observable, catchError, map, of } from 'rxjs';
-import { PrismaService } from './Db/prisma.service';
 
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {
-  constructor(private readonly PrismaService: PrismaService,) { }
+  // constructor(private readonly PrismaService: PrismaService,) { }
 
-  async intercept(context: ExecutionContext, next: CallHandler): Promise<Observable<any>> {
-    let req = context.switchToHttp().getRequest();
-    let res = context.switchToHttp().getResponse();
-  
-    if (req.method != 'GET' || !req.url.includes('/auth/login')) {
-      await this.PrismaService.system_logger.create({
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    /*  let request=  context.switchToHttp().getRequest();
+     
+      this.PrismaService.systemlogger.create({
         data: {
-          Action: req.method,
-          UserId: req.headers['user'] == undefined ? "LOGIN" : '' + req.headers['user']['userId'] ?? 'no id',
-          TableName: req.url,
-          Record_Befor: req.body == undefined ? null : req.body.toString(),
-          Record_After: res.data,
+          UserId:+request.user.userId,
+          JsonData: request.body,
+          TableName:'TableName',
+          Action:'Action',
+          CreatedDate:new Date().toISOString(),
         }
       });
-    }
-    return next.handle().pipe(
+      */
 
+    return next.handle().pipe(
       map((data) => ({
         status: true,
         // statusCode: context.switchToHttp().getResponse().statusCode,

--- a/src/Component/Mission/control_mission/control_mission.module.ts
+++ b/src/Component/Mission/control_mission/control_mission.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
-import { ControlMissionService } from './control_mission.service';
+import { PrismaModule } from 'src/Common/Db/prisma.module';
 import { ControlMissionController } from './control_mission.controller';
-import { PrismaService } from 'src/Common/Db/prisma.service';
+import { ControlMissionService } from './control_mission.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [ControlMissionController],
-  providers: [ControlMissionService, PrismaService],
+  providers: [ControlMissionService],
 })
 export class ControlMissionModule {}

--- a/src/Component/Mission/exam_mission/exam_mission.module.ts
+++ b/src/Component/Mission/exam_mission/exam_mission.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
-import { PrismaService } from 'src/Common/Db/prisma.service';
+import { PrismaModule } from 'src/Common/Db/prisma.module';
 import { ExamMissionController } from './exam_mission.controller';
 import { ExamMissionService } from './exam_mission.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [ExamMissionController],
-  providers: [ExamMissionService, PrismaService],
+  providers: [ExamMissionService],
   exports: [ExamMissionService],
 })
 export class ExamMissionModule {}

--- a/src/Component/Mission/exam_mission/exam_mission.service.ts
+++ b/src/Component/Mission/exam_mission/exam_mission.service.ts
@@ -224,7 +224,7 @@ export class ExamMissionService {
       data: {
         Active: 1,
         Updated_By: updatedBy,
-        Updated_At: new Date(),
+        Updated_At: new Date().toISOString(),
       },
     });
     return result;

--- a/src/Component/Mission/exam_rooms/exam_rooms.module.ts
+++ b/src/Component/Mission/exam_rooms/exam_rooms.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
-import { PrismaService } from 'src/Common/Db/prisma.service';
+import { PrismaModule } from 'src/Common/Db/prisma.module';
 import { ExamRoomsController } from './exam_rooms.controller';
 import { ExamRoomsService } from './exam_rooms.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [ExamRoomsController],
-  providers: [ExamRoomsService, PrismaService],
+  providers: [ExamRoomsService],
 })
 export class ExamRoomsModule {}

--- a/src/Component/Mission/exam_rooms/exam_rooms.service.ts
+++ b/src/Component/Mission/exam_rooms/exam_rooms.service.ts
@@ -386,7 +386,7 @@ export class ExamRoomsService {
       data: {
         ...updateExamRoomteDto,
         Updated_By: Updated_By,
-        Updated_At: new Date().toString(),
+        Updated_At: new Date().toISOString(),
       },
     });
     return result;

--- a/src/Component/Mission/generate_pdf/generate_pdf.module.ts
+++ b/src/Component/Mission/generate_pdf/generate_pdf.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
-import { GeneratePdfService } from './generate_pdf.service';
+import { PrismaModule } from 'src/Common/Db/prisma.module';
 import { GeneratePdfController } from './generate_pdf.controller';
-import { ComponantServices } from './pdfComponant.services';
-import { PrismaService } from 'src/Common/Db/prisma.service';
+import { GeneratePdfService } from './generate_pdf.service';
+import { PdfComponantModule } from './pdfComponant.module';
 
 @Module({
+  imports: [PrismaModule, PdfComponantModule],
   controllers: [GeneratePdfController],
-  providers: [GeneratePdfService, ComponantServices, PrismaService],
+  providers: [GeneratePdfService],
 })
 export class GeneratePdfModule {}

--- a/src/Component/Mission/generate_pdf/pdfComponant.module.ts
+++ b/src/Component/Mission/generate_pdf/pdfComponant.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ComponantServices } from './pdfComponant.services';
+
+@Module({
+  providers: [ComponantServices],
+  exports: [ComponantServices],
+})
+export class PdfComponantModule {}

--- a/src/Component/Mission/student_barcodes/student_barcodes.module.ts
+++ b/src/Component/Mission/student_barcodes/student_barcodes.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
-import { StudentBarcodesService } from './student_barcodes.service';
+import { PrismaModule } from 'src/Common/Db/prisma.module';
 import { StudentBarcodesController } from './student_barcodes.controller';
-import { PrismaService } from 'src/Common/Db/prisma.service';
+import { StudentBarcodesService } from './student_barcodes.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [StudentBarcodesController],
-  providers: [StudentBarcodesService, PrismaService],
+  providers: [StudentBarcodesService],
 })
 export class StudentBarcodesModule {}

--- a/src/Component/Mission/student_seat_numbers/student_seat_numbers.module.ts
+++ b/src/Component/Mission/student_seat_numbers/student_seat_numbers.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
-import { StudentSeatNumbersService } from './student_seat_numbers.service';
+import { PrismaModule } from 'src/Common/Db/prisma.module';
 import { StudentSeatNumbersController } from './student_seat_numbers.controller';
-import { PrismaService } from 'src/Common/Db/prisma.service';
+import { StudentSeatNumbersService } from './student_seat_numbers.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [StudentSeatNumbersController],
-  providers: [StudentSeatNumbersService, PrismaService],
+  providers: [StudentSeatNumbersService],
 })
 export class StudentSeatNumbersModule {}

--- a/src/Component/School_Setting/class_desk/class_desk.module.ts
+++ b/src/Component/School_Setting/class_desk/class_desk.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
-import { ClassDeskService } from './class_desk.service';
+import { PrismaModule } from '../../../Common/Db/prisma.module';
 import { ClassDeskController } from './class_desk.controller';
-import { PrismaService } from 'src/Common/Db/prisma.service';
+import { ClassDeskService } from './class_desk.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [ClassDeskController],
-  providers: [ClassDeskService, PrismaService],
+  providers: [ClassDeskService],
 })
 export class ClassDeskModule {}

--- a/src/Component/School_Setting/cohort/cohort.module.ts
+++ b/src/Component/School_Setting/cohort/cohort.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
-import { CohortService } from './cohort.service';
+import { PrismaModule } from 'src/Common/Db/prisma.module';
 import { CohortController } from './cohort.controller';
-import { PrismaService } from 'src/Common/Db/prisma.service';
+import { CohortService } from './cohort.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [CohortController],
-  providers: [CohortService, PrismaService],
+  providers: [CohortService],
 })
 export class CohortModule {}

--- a/src/Component/School_Setting/cohort/cohort.service.ts
+++ b/src/Component/School_Setting/cohort/cohort.service.ts
@@ -181,7 +181,7 @@ export class CohortService {
       data: {
         ...updateCohortDto,
         Updated_By: updatedBy,
-        Updated_At: new Date().toString(),
+        Updated_At: new Date().toISOString(),
       },
     });
     return result;

--- a/src/Component/School_Setting/education_year/education_year.module.ts
+++ b/src/Component/School_Setting/education_year/education_year.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
-import { EducationYearService } from './education_year.service';
+import { PrismaModule } from 'src/Common/Db/prisma.module';
 import { EducationYearController } from './education_year.controller';
-import { PrismaService } from 'src/Common/Db/prisma.service';
+import { EducationYearService } from './education_year.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [EducationYearController],
-  providers: [EducationYearService, PrismaService],
+  providers: [EducationYearService],
 })
 export class EducationYearModule {}

--- a/src/Component/School_Setting/grades/grades.module.ts
+++ b/src/Component/School_Setting/grades/grades.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
-import { GradesService } from './grades.service';
+import { PrismaModule } from 'src/Common/Db/prisma.module';
 import { GradesController } from './grades.controller';
-import { PrismaService } from 'src/Common/Db/prisma.service';
+import { GradesService } from './grades.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [GradesController],
-  providers: [GradesService, PrismaService],
+  providers: [GradesService],
 })
 export class GradesModule {}

--- a/src/Component/School_Setting/grades/grades.service.ts
+++ b/src/Component/School_Setting/grades/grades.service.ts
@@ -45,7 +45,7 @@ export class GradesService {
       data: {
         ...updateGradeDto,
         Updated_By: Updated_By,
-        Updated_At: new Date(),
+        Updated_At: new Date().toISOString(),
       },
     });
     return result;

--- a/src/Component/School_Setting/school_classes/school_classes.module.ts
+++ b/src/Component/School_Setting/school_classes/school_classes.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
-import { SchoolClassesService } from './school_classes.service';
+import { PrismaModule } from 'src/Common/Db/prisma.module';
 import { SchoolClassesController } from './school_classes.controller';
-import { PrismaService } from 'src/Common/Db/prisma.service';
+import { SchoolClassesService } from './school_classes.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [SchoolClassesController],
-  providers: [SchoolClassesService, PrismaService],
+  providers: [SchoolClassesService],
   exports: [SchoolClassesService],
 })
 export class SchoolClassesModule {}

--- a/src/Component/School_Setting/school_classes/school_classes.service.ts
+++ b/src/Component/School_Setting/school_classes/school_classes.service.ts
@@ -120,7 +120,7 @@ export class SchoolClassesService {
       data: {
         ...updateSchoolClassDto,
         Updated_By: updatedBy,
-        Updated_At: new Date(),
+        Updated_At: new Date().toISOString(),
       },
     });
     return result;

--- a/src/Component/School_Setting/school_type/school_type.module.ts
+++ b/src/Component/School_Setting/school_type/school_type.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
-import { SchoolTypeService } from './school_type.service';
+import { PrismaModule } from 'src/Common/Db/prisma.module';
 import { SchoolTypeController } from './school_type.controller';
-import { PrismaService } from 'src/Common/Db/prisma.service';
+import { SchoolTypeService } from './school_type.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [SchoolTypeController],
-  providers: [SchoolTypeService, PrismaService],
+  providers: [SchoolTypeService],
 })
 export class SchoolTypeModule {}

--- a/src/Component/School_Setting/schools/schools.module.ts
+++ b/src/Component/School_Setting/schools/schools.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
-import { SchoolsService } from './schools.service';
+import { PrismaModule } from 'src/Common/Db/prisma.module';
 import { SchoolsController } from './schools.controller';
-import { PrismaService } from 'src/Common/Db/prisma.service';
+import { SchoolsService } from './schools.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [SchoolsController],
-  providers: [SchoolsService, PrismaService],
+  providers: [SchoolsService],
 })
 export class SchoolsModule {}

--- a/src/Component/School_Setting/schools/schools.service.ts
+++ b/src/Component/School_Setting/schools/schools.service.ts
@@ -64,7 +64,7 @@ export class SchoolsService {
       data: {
         ...updateSchoolDto,
         Updated_By: Updated_By,
-        Updated_At: new Date().toString(),
+        Updated_At: new Date().toISOString(),
       },
     });
     return result;

--- a/src/Component/School_Setting/stage/stage.module.ts
+++ b/src/Component/School_Setting/stage/stage.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
-import { PrismaService } from 'src/Common/Db/prisma.service';
+import { PrismaModule } from 'src/Common/Db/prisma.module';
 import { StageController } from './stage.controller';
 import { StageService } from './stage.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [StageController],
-  providers: [StageService, PrismaService],
+  providers: [StageService],
 })
 export class StageModule {}

--- a/src/Component/School_Setting/stage/stage.service.ts
+++ b/src/Component/School_Setting/stage/stage.service.ts
@@ -41,7 +41,7 @@ export class StageService {
       data: {
         ...updateStageeDto,
         Updated_By: Updated_By,
-        Updated_At: new Date(),
+        Updated_At: new Date().toISOString(),
       },
     });
     return result;

--- a/src/Component/School_Setting/subjects/subjects.module.ts
+++ b/src/Component/School_Setting/subjects/subjects.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
-import { SubjectsService } from './subjects.service';
+import { PrismaModule } from '../../../Common/Db/prisma.module';
 import { SubjectsController } from './subjects.controller';
-import { PrismaService } from 'src/Common/Db/prisma.service';
-
+import { SubjectsService } from './subjects.service';
 @Module({
+  imports: [PrismaModule],
   controllers: [SubjectsController],
-  providers: [SubjectsService, PrismaService],
+  providers: [SubjectsService],
 })
 export class SubjectsModule {}

--- a/src/Component/School_Setting/subjects/subjects.service.ts
+++ b/src/Component/School_Setting/subjects/subjects.service.ts
@@ -81,7 +81,7 @@ export class SubjectsService {
       },
       data: {
         Updated_By: updatedBy,
-        Updated_At: new Date(),
+        Updated_At: new Date().toISOString(),
         school_type_has_subjects: {
           delete: {
             school_type_ID_subjects_ID: {
@@ -155,7 +155,7 @@ export class SubjectsService {
         Name: updateSubjecteDto.Name,
         InExam: updateSubjecteDto.InExam,
         Updated_By: updatedBy,
-        Updated_At: new Date(),
+        Updated_At: new Date().toISOString(),
         school_type_has_subjects: {
           create: schoolTypeHasSubject,
         },
@@ -182,7 +182,7 @@ export class SubjectsService {
       data: {
         InExam: number,
         Updated_By: updatedBy,
-        Updated_At: new Date(),
+        Updated_At: new Date().toISOString(),
       },
     });
     return result;
@@ -221,7 +221,7 @@ export class SubjectsService {
       data: {
         Active: 1,
         Updated_By: updatedBy,
-        Updated_At: new Date(),
+        Updated_At: new Date().toISOString(),
       },
     });
     return result;
@@ -235,7 +235,7 @@ export class SubjectsService {
       data: {
         Active: 0,
         Updated_By: updatedBy,
-        Updated_At: new Date(),
+        Updated_At: new Date().toISOString(),
       },
     });
     return result;

--- a/src/Component/auth/auth.module.ts
+++ b/src/Component/auth/auth.module.ts
@@ -14,5 +14,6 @@ import { JwtStrategy } from './startgy/jwt.strategy';
       secret: 'asdfds$23cdscads^^3243',
     }),
   ],
+  exports: [AuthService],
 })
 export class AuthModule {}

--- a/src/Component/proctor/proctor.module.ts
+++ b/src/Component/proctor/proctor.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
-import { PrismaService } from 'src/Common/Db/prisma.service';
+import { PrismaModule } from 'src/Common/Db/prisma.module';
 import { ProctorController } from './proctor.controller';
 import { ProctorService } from './proctor.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [ProctorController],
-  providers: [ProctorService, PrismaService],
+  providers: [ProctorService],
 })
 export class ProctorModule {}

--- a/src/Component/proctor/proctor.service.ts
+++ b/src/Component/proctor/proctor.service.ts
@@ -97,7 +97,7 @@ export class ProctorService {
       data: {
         ...updateProctorDto,
         Updated_By: updatedBy,
-        Updated_At: new Date(),
+        Updated_At: new Date().toISOString(),
       },
     });
     return result;

--- a/src/Component/student/student.module.ts
+++ b/src/Component/student/student.module.ts
@@ -1,12 +1,11 @@
 import { Module } from '@nestjs/common';
-import { StudentService } from './student.service';
+import { PrismaModule } from '../../Common/Db/prisma.module';
 import { StudentController } from './student.controller';
-import { PrismaService } from 'src/Common/Db/prisma.service';
-
+import { StudentService } from './student.service';
 @Module({
   controllers: [StudentController],
-  providers: [StudentService, PrismaService],
+  providers: [StudentService],
   exports: [StudentService],
-  imports: [],
+  imports: [PrismaModule],
 })
 export class StudentModule {}

--- a/src/Component/uuid/uuid.module.ts
+++ b/src/Component/uuid/uuid.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
-import { PrismaService } from 'src/Common/Db/prisma.service';
-import { ExamMissionService } from '../Mission/exam_mission/exam_mission.service';
+import { PrismaModule } from 'src/Common/Db/prisma.module';
+import { ExamMissionModule } from '../Mission/exam_mission/exam_mission.module';
 import { UuidController } from './uuid.controller';
 import { UuidService } from './uuid.service';
 
 @Module({
+  imports: [PrismaModule, ExamMissionModule],
   controllers: [UuidController],
-  providers: [UuidService, PrismaService, ExamMissionService],
+  providers: [UuidService],
 })
 export class UuidModule {}

--- a/src/Users_System/user_roles_systems/user_roles_systems.module.ts
+++ b/src/Users_System/user_roles_systems/user_roles_systems.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
-import { UserRolesSystemsService } from './user_roles_systems.service';
+import { PrismaModule } from 'src/Common/Db/prisma.module';
 import { UserRolesSystemsController } from './user_roles_systems.controller';
-import { PrismaService } from 'src/Common/Db/prisma.service';
-
+import { UserRolesSystemsService } from './user_roles_systems.service';
 @Module({
+  imports: [PrismaModule],
+
   controllers: [UserRolesSystemsController],
-  providers: [UserRolesSystemsService, PrismaService],
+  providers: [UserRolesSystemsService],
   exports: [UserRolesSystemsService],
 })
 export class UserRolesSystemsModule {}

--- a/src/Users_System/users/users.module.ts
+++ b/src/Users_System/users/users.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
-import { UsersService } from './users.service';
+import { PrismaModule } from 'src/Common/Db/prisma.module';
 import { UsersController } from './users.controller';
-import { PrismaService } from 'src/Common/Db/prisma.service';
+import { UsersService } from './users.service';
 
 @Module({
+  imports: [PrismaModule],
   exports: [UsersService],
   controllers: [UsersController],
-  providers: [UsersService, PrismaService],
+  providers: [UsersService],
 })
 export class UsersModule {}

--- a/src/Users_System/users/users.service.ts
+++ b/src/Users_System/users/users.service.ts
@@ -600,85 +600,85 @@ export class UsersService {
     updateUserCreateUserDto: UpdateUserDto,
     updatedBy: number,
   ) {
-    if (
-      updateUserCreateUserDto.OldPassword &&
-      updateUserCreateUserDto.NewPassword
-    ) {
-      var user = await this.prismaService.users.findUnique({
-        where: {
-          ID: id,
-        },
-      });
-      //------------------------------------------------------------------------------------------------------//
-      // if ( !bcrypt.compareSync( updateUserCreateUserDto.OldPassword, user.Password ) )
-      // {
-      //   throw new HttpException(
-      // 'Old Password does not match.',
-      //   HttpStatus.FORBIDDEN,
-      //   );
-      // }
+    // if (
+    //   updateUserCreateUserDto.OldPassword &&
+    //   updateUserCreateUserDto.NewPassword
+    // ) {
+    //   var user = await this.prismaService.users.findUnique({
+    //     where: {
+    //       ID: id,
+    //     },
+    //   });
+    //------------------------------------------------------------------------------------------------------//
+    // if ( !bcrypt.compareSync( updateUserCreateUserDto.OldPassword, user.Password ) )
+    // {
+    //   throw new HttpException(
+    // 'Old Password does not match.',
+    //   HttpStatus.FORBIDDEN,
+    //   );
+    // }
 
-      // if ( updateUserCreateUserDto.NewPassword == updateUserCreateUserDto.OldPassword )
-      // {
-      //   throw new HttpException(
-      // 'Old Password does not match.',
-      // HttpStatus.FORBIDDEN,
-      // );
-      // }
+    // if ( updateUserCreateUserDto.NewPassword == updateUserCreateUserDto.OldPassword )
+    // {
+    //   throw new HttpException(
+    // 'Old Password does not match.',
+    // HttpStatus.FORBIDDEN,
+    // );
+    // }
 
-      // user.Password = bcrypt.hashSync( updateUserCreateUserDto.NewPassword, 10 );
-      // user.Updated_By = updatedBy;
-      // user.Updated_At = new Date();
-      // var result = await this.prismaService.users.update( {
-      //   where: {
-      //     ID: id,
-      //   },
-      //   data: user,
-      // } );
-      // return result;
-      //------------------------------------------------------------------------------------------------------//
+    // user.Password = bcrypt.hashSync( updateUserCreateUserDto.NewPassword, 10 );
+    // user.Updated_By = updatedBy;
+    // user.Updated_At = new Date();
+    // var result = await this.prismaService.users.update( {
+    //   where: {
+    //     ID: id,
+    //   },
+    //   data: user,
+    // } );
+    // return result;
+    //------------------------------------------------------------------------------------------------------//
 
-      // perform normal check without bcrypt for now
+    // perform normal check without bcrypt for now
 
-      if (updateUserCreateUserDto.OldPassword != user.Password) {
-        throw new HttpException(
-          'Old Password does not match.',
-          HttpStatus.FORBIDDEN,
-        );
-      }
+    //   if (updateUserCreateUserDto.OldPassword != user.Password) {
+    //     throw new HttpException(
+    //       'Old Password does not match.',
+    //       HttpStatus.FORBIDDEN,
+    //     );
+    //   }
 
-      if (
-        updateUserCreateUserDto.NewPassword ==
-        updateUserCreateUserDto.OldPassword
-      ) {
-        throw new HttpException(
-          'New Password cannot be same as Old Password.',
-          HttpStatus.FORBIDDEN,
-        );
-      }
-      user.Password = updateUserCreateUserDto.NewPassword;
-      user.Updated_By = updatedBy;
-      user.Updated_At = new Date().toString();
-      var result = await this.prismaService.users.update({
-        where: {
-          ID: id,
-        },
-        data: user,
-      });
-      return result;
-    } else {
-      var result = await this.prismaService.users.update({
-        where: {
-          ID: id,
-        },
-        data: {
-          ...updateUserCreateUserDto,
-          Updated_By: updatedBy,
-          Updated_At: new Date().toString(),
-        },
-      });
-      return result;
-    }
+    //   if (
+    //     updateUserCreateUserDto.NewPassword ==
+    //     updateUserCreateUserDto.OldPassword
+    //   ) {
+    //     throw new HttpException(
+    //       'New Password cannot be same as Old Password.',
+    //       HttpStatus.FORBIDDEN,
+    //     );
+    //   }
+    //   user.Password = updateUserCreateUserDto.NewPassword;
+    //   user.Updated_By = updatedBy;
+    //   user.Updated_At = new Date().toString();
+    //   var result = await this.prismaService.users.update({
+    //     where: {
+    //       ID: id,
+    //     },
+    //     data: user,
+    //   });
+    //   return result;
+    // } else {
+    var result = await this.prismaService.users.update({
+      where: {
+        ID: id,
+      },
+      data: {
+        ...updateUserCreateUserDto,
+        Updated_By: updatedBy,
+        Updated_At: new Date().toISOString(),
+      },
+    });
+    return result;
+    // }
   }
 
   async remove(id: number) {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,7 @@ import { FastifyMulterModule } from '@nest-lab/fastify-multer';
 import { MiddlewareConsumer, Module, RequestMethod } from '@nestjs/common';
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
+import { PrismaModule } from './Common/Db/prisma.module';
 import { AuthGuard } from './Common/Guard/auth.guard';
 import { RolesGuard } from './Common/Guard/roles.guard';
 import { NisConvertJson } from './Common/MiddleWare/ConvertJson.middleware';
@@ -19,24 +20,22 @@ import { GradesModule } from './Component/School_Setting/grades/grades.module';
 import { SchoolClassesModule } from './Component/School_Setting/school_classes/school_classes.module';
 import { SchoolTypeModule } from './Component/School_Setting/school_type/school_type.module';
 import { SchoolsModule } from './Component/School_Setting/schools/schools.module';
+import { StageModule } from './Component/School_Setting/stage/stage.module';
 import { SubjectsModule } from './Component/School_Setting/subjects/subjects.module';
 import { AuthModule } from './Component/auth/auth.module';
-import { AuthService } from './Component/auth/auth.service';
+import { ProctorModule } from './Component/proctor/proctor.module';
 import { StudentModule } from './Component/student/student.module';
+import { UuidModule } from './Component/uuid/uuid.module';
 import { UserRolesSystemsModule } from './Users_System/user_roles_systems/user_roles_systems.module';
 import { UsersModule } from './Users_System/users/users.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { WebsocketGateway } from './websocket.gateway';
-import { StageModule } from './Component/School_Setting/stage/stage.module';
-import { ProctorModule } from './Component/proctor/proctor.module';
-import { UuidModule } from './Component/uuid/uuid.module';
-import { PrismaService } from './Common/Db/prisma.service';
 
 @Module({
   imports: [
     FastifyMulterModule.register({ dest: './uploads' }),
     // ConfigModule.forRoot(),
+    PrismaModule,
     AuthModule,
     SchoolsModule,
     GradesModule,
@@ -62,10 +61,9 @@ import { PrismaService } from './Common/Db/prisma.service';
   controllers: [AppController],
   providers: [
     AppService,
-    AuthService,
+    // AuthService,
     JwtService,
-    PrismaService,
-    WebsocketGateway,
+    // WebsocketGateway,
     {
       provide: APP_INTERCEPTOR,
       useClass: LoggingInterceptor,


### PR DESCRIPTION
This commit migrates the Prisma service from being a provider in various modules to a centralized Prisma module. This change ensures that the Prisma client is only initialized once and can be easily shared across multiple modules. Additionally, the commit updates the `Updated_At` field in the `subjects.service.ts` file to use the ISO string format.