### PR TITLE
🐛 fix(StudentBarcodes): Handle barcode not found error

### DIFF
--- a/src/Component/Mission/student_barcodes/student_barcodes.service.ts
+++ b/src/Component/Mission/student_barcodes/student_barcodes.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/Common/Db/prisma.service';
 import { CreateStudentBarcodeDto } from './dto/create-student_barcode.dto';
 import { UpdateStudentBarcodeDto } from './dto/update-student_barcode.dto';
@@ -115,7 +115,11 @@ export class StudentBarcodesService {
         },
       },
     });
-
+    if (!result)
+      throw new HttpException(
+        'Barcode not found. Please make sure that the barcode is correct.',
+        HttpStatus.NOT_FOUND,
+      );
     var studentsDegreesCounter =
       await this.prismaService.student_barcode.findMany({
         where: {


### PR DESCRIPTION
When a barcode is not found in the database, throw a 404 HTTP exception with a
meaningful error message. This ensures that the client is aware of the issue
and can take appropriate action.