### PR TITLE
✨ feat(prisma): remove unique constraint from exam_room name

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -114,7 +114,7 @@ model exam_room {
   ID                         Int                          @id @unique(map: "ID_UNIQUE") @default(autoincrement())
   Control_Mission_ID         Int
   School_Class_ID            Int
-  Name                       String                       @unique(map: "Name_UNIQUE") @db.VarChar(45)
+  Name                       String                       @db.VarChar(45)
   Stage                      String                       @db.VarChar(45)
   Created_By                 Int?
   Created_At                 DateTime                     @default(now()) @db.Timestamp(0)


### PR DESCRIPTION
Removes the unique constraint from the `Name` field in the `exam_room` model. This
change allows for multiple exam rooms to have the same name, which may be
necessary in some use cases.