### PR TITLE
🔖 feat(cohort): Add `school_type` to cohort API responses

### DIFF
--- a/src/Component/School_Setting/cohort/cohort.service.ts
+++ b/src/Component/School_Setting/cohort/cohort.service.ts
@@ -20,6 +20,7 @@ export class CohortService {
     var result = await this.prismaService.cohort.create({
       data: { ...createCohortDto, Created_By: createdBy },
       include: {
+        school_type: true,
         cohort_has_subjects: {
           include: {
             subjects: {
@@ -38,6 +39,7 @@ export class CohortService {
   async findAll() {
     var results = await this.prismaService.cohort.findMany({
       include: {
+        school_type: true,
         cohort_has_subjects: {
           include: {
             subjects: {
@@ -55,6 +57,7 @@ export class CohortService {
   async findAllBySchoolId(schoolId: number) {
     var results = await this.prismaService.cohort.findMany({
       include: {
+        school_type: true,
         cohort_has_subjects: {
           include: {
             subjects: {
@@ -86,6 +89,7 @@ export class CohortService {
         ID: id,
       },
       include: {
+        school_type: true,
         cohort_has_subjects: {
           include: {
             subjects: {
@@ -144,6 +148,7 @@ export class CohortService {
         ID: cohortId,
       },
       include: {
+        school_type: true,
         cohort_has_subjects: {
           include: {
             subjects: {


### PR DESCRIPTION
The changes made in this commit add the `school_type` relation to the cohort API responses. This ensures that the school type information is included in the response, providing a more complete view of the cohort data.

The changes were made in the `CohortService` class, where the `include` option in the Prisma queries was updated to include the `school_type` relation. This change was applied to the following methods:

- `findAll()`
- `findAllBySchoolId()`
- `findOne()`
- `create()`
- `update()`

This improvement will enhance the functionality of the cohort management system, allowing users to access the school type information associated with each cohort.