### PR TITLE
✨ feat(app): Enable app to listen on port 80

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -149,7 +149,7 @@ async function bootstrap() {
    * This is necessary to start the server and
    * make it listen on port 80.
    */
-  await app.listen({ port: 3333, host: '0.0.0.0' });
+  await app.listen({ port: 80, host: '0.0.0.0' });
 
   /**
    * Set up the hot reloading


### PR DESCRIPTION
Changes the port the app is listening on from 3333 to 80.
This is necessary to make the app accessible on the default
HTTP port without requiring a custom port in the URL.